### PR TITLE
feat: add pagerow limit extension (500개까지 보기 옵션)

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -230,6 +230,13 @@
                 <span class="slider"></span>
             </label>
         </div>
+        <div class="setting-row">
+            <span class="setting-label">500개까지 보기 옵션 추가</span>
+            <label class="toggle-switch">
+                <input type="checkbox" id="extendPagerow" checked>
+                <span class="slider"></span>
+            </label>
+        </div>
     </div>
     
     <div class="setting-group">
@@ -243,6 +250,7 @@
                 • <strong>단순수리</strong>: 외판부위만 수리<br>
                 • <strong>사고 있음</strong>: 사고 이력 있음
             </p>
+            <p>4. <span class="highlight">"페이지당 개수"</span>를 최대 500개까지 선택 가능</p>
         </div>
     </div>
     

--- a/popup.js
+++ b/popup.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const hidePhotoToggle = document.getElementById('hidePhotoSection');
     const hidePriorityToggle = document.getElementById('hidePrioritySection');
     const showUsageHistoryToggle = document.getElementById('showUsageHistory');
+    const extendPagerowToggle = document.getElementById('extendPagerow');
     
     // 초기화
     loadVersionInfo();
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadPhotoSectionSettings();
     loadPrioritySectionSettings();
     loadUsageHistorySettings();
+    loadPagerowSettings();
     
     // 사진우대 섹션 토글 이벤트
     hidePhotoToggle.addEventListener('change', function() {
@@ -31,6 +33,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // 사용이력 표시 토글 이벤트
     showUsageHistoryToggle.addEventListener('change', function() {
         saveUsageHistorySettings(this.checked);
+        updateActiveTab();
+    });
+    
+    // Pagerow 확장 토글 이벤트
+    extendPagerowToggle.addEventListener('change', function() {
+        savePagerowSettings(this.checked);
         updateActiveTab();
     });
     
@@ -122,6 +130,23 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
+    // Pagerow 확장 설정 로드
+    function loadPagerowSettings() {
+        chrome.storage.sync.get(['extendPagerow'], function(result) {
+            const isEnabled = result.extendPagerow !== false; // 기본값 true
+            extendPagerowToggle.checked = isEnabled;
+        });
+    }
+    
+    // Pagerow 확장 설정 저장
+    function savePagerowSettings(isEnabled) {
+        chrome.storage.sync.set({
+            extendPagerow: isEnabled
+        }, function() {
+            console.log('Pagerow extension setting saved:', isEnabled);
+        });
+    }
+    
     // 활성 탭에 메시지 전송
     function updateActiveTab() {
         chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
@@ -130,7 +155,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     action: 'toggleSections',
                     hidePhotoSection: hidePhotoToggle.checked,
                     hidePrioritySection: hidePriorityToggle.checked,
-                    showUsageHistory: showUsageHistoryToggle.checked
+                    showUsageHistory: showUsageHistoryToggle.checked,
+                    extendPagerow: extendPagerowToggle.checked
                 });
             }
         });


### PR DESCRIPTION
## Summary
엔카 검색 결과 페이지에서 한 번에 볼 수 있는 차량 개수를 최대 500개까지 확장할 수 있는 기능을 추가했습니다.

## 새로운 기능
- **popup UI**: "500개까지 보기 옵션 추가" 토글 스위치 추가
- **동적 옵션 확장**: 기존 20,30,40,50에서 100,200,300,400,500까지 확장
- **토글 기능**: 활성화/비활성화로 옵션 추가/제거 가능
- **설정 저장**: Chrome Storage를 통한 사용자 설정 자동 저장/복원
- **호환성**: 엔카 기존 시스템과 완전 호환

## 기술적 개선사항
- knockout.js data-bind 속성과 정적 option 태그 모두 지원
- 다중 선택자를 통한 안정적인 DOM 요소 탐지
- 중복 처리 방지 및 에러 핸들링
- 페이지 로드 타이밍 최적화
- 토글 해제 시 원래 상태로 완전 복원

## 사용법
1. Extension 팝업에서 "500개까지 보기 옵션 추가" 토글 활성화
2. 엔카 검색 페이지에서 "페이지당 개수" 선택박스 확인
3. 100개, 200개, 300개, 400개, 500개 옵션 선택 가능

## Test plan
- [x] popup 토글 스위치 동작 확인
- [x] pagerow select 요소 탐지 및 옵션 확장
- [x] 토글 활성화/비활성화 시 옵션 추가/제거
- [x] Chrome Storage 설정 저장/복원
- [x] 엔카 기존 기능과 호환성 확인