### PR TITLE
feat: 보험 미가입기간 라벨 추가 및 분홍색 스타일링

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -245,6 +245,13 @@
             </label>
         </div>
         <div class="setting-row">
+            <span class="setting-label">보험 미가입기간 표시하기</span>
+            <label class="toggle-switch">
+                <input type="checkbox" id="showNoInsuranceHistory" checked>
+                <span class="slider"></span>
+            </label>
+        </div>
+        <div class="setting-row">
             <span class="setting-label">500개까지 보기 옵션 추가</span>
             <label class="toggle-switch">
                 <input type="checkbox" id="extendPagerow" checked>

--- a/popup.js
+++ b/popup.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const showUsageHistoryToggle = document.getElementById('showUsageHistory');
     const showInsuranceHistoryToggle = document.getElementById('showInsuranceHistory');
     const showOwnerHistoryToggle = document.getElementById('showOwnerHistory');
+    const showNoInsuranceHistoryToggle = document.getElementById('showNoInsuranceHistory');
     const extendPagerowToggle = document.getElementById('extendPagerow');
     
     // 초기화
@@ -20,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadUsageHistorySettings();
     loadInsuranceHistorySettings();
     loadOwnerHistorySettings();
+    loadNoInsuranceHistorySettings();
     loadPagerowSettings();
     
     // 사진우대 섹션 토글 이벤트
@@ -49,6 +51,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // 소유자 변경이력 표시 토글 이벤트
     showOwnerHistoryToggle.addEventListener('change', function() {
         saveOwnerHistorySettings(this.checked);
+        updateActiveTab();
+    });
+    
+    // 보험 미가입기간 표시 토글 이벤트
+    showNoInsuranceHistoryToggle.addEventListener('change', function() {
+        saveNoInsuranceHistorySettings(this.checked);
         updateActiveTab();
     });
     
@@ -180,6 +188,23 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     
+    // 보험 미가입기간 표시 설정 로드
+    function loadNoInsuranceHistorySettings() {
+        chrome.storage.sync.get(['showNoInsuranceHistory'], function(result) {
+            const isEnabled = result.showNoInsuranceHistory !== false; // 기본값 true
+            showNoInsuranceHistoryToggle.checked = isEnabled;
+        });
+    }
+    
+    // 보험 미가입기간 표시 설정 저장
+    function saveNoInsuranceHistorySettings(isEnabled) {
+        chrome.storage.sync.set({
+            showNoInsuranceHistory: isEnabled
+        }, function() {
+            console.log('No insurance history setting saved:', isEnabled);
+        });
+    }
+    
     // Pagerow 확장 설정 로드
     function loadPagerowSettings() {
         chrome.storage.sync.get(['extendPagerow'], function(result) {
@@ -208,6 +233,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     showUsageHistory: showUsageHistoryToggle.checked,
                     showInsuranceHistory: showInsuranceHistoryToggle.checked,
                     showOwnerHistory: showOwnerHistoryToggle.checked,
+                    showNoInsuranceHistory: showNoInsuranceHistoryToggle.checked,
                     extendPagerow: extendPagerowToggle.checked
                 });
             }

--- a/styles.css
+++ b/styles.css
@@ -302,10 +302,27 @@
     background: #5a32a3 !important;
 }
 
+/* 보험 미가입 기간 라벨 스타일 */
+.noinsurance-label {
+    background: #e83e8c !important;
+    color: white !important;
+    padding: 2px 6px !important;
+    border-radius: 3px !important;
+    font-size: 11px !important;
+    margin-right: 3px !important;
+    display: inline-block !important;
+    font-weight: normal !important;
+}
+
+.noinsurance-label:hover {
+    background: #d91a72 !important;
+}
+
 /* 사진우대영역 라벨 크기 조정 (small_label과 일치) */
 #sr_photo .usage-history-label,
 #sr_photo .insurance-history-label,
-#sr_photo .owner-change-label {
+#sr_photo .owner-change-label,
+#sr_photo .noinsurance-label {
     font-size: 10px !important;
     padding: 1px 4px !important;
     margin-right: 2px !important;
@@ -321,5 +338,9 @@
 }
 
 .hide-owner-labels .owner-change-label {
+    display: none !important;
+}
+
+.hide-noinsurance-labels .noinsurance-label {
     display: none !important;
 }


### PR DESCRIPTION
## 개요
엔카 차량 검색 결과에 보험 미가입기간 정보를 표시하는 라벨 기능을 추가했습니다.

## 주요 기능
• API의 `notJoinDate1~5` 데이터를 파싱하여 총 미가입 개월수 계산
• "보험 미가입 N개월" 형태로 라벨 표시
• 분홍색(#e83e8c) 스타일링으로 다른 라벨과 구분
• 팝업에서 표시/숨김 토글 제어 가능
• 일반 검색결과와 사진우대영역 모두 지원

## 기술적 구현
• `calculateNoInsuranceMonths()` 함수로 "YYYYMM~YYYYMM" 형식 파싱
• `fetchVehicleHistory()` 함수에 미가입기간 처리 로직 추가
• CSS에 `.noinsurance-label` 스타일 추가 (분홍색)
• 팝업 토글 및 Chrome Storage 연동
• 기존 라벨 시스템 아키텍처 유지

## 변경 파일
- `content.js`: 미가입기간 계산 및 라벨 생성 로직
- `styles.css`: 분홍색 라벨 스타일링
- `popup.html`: 토글 스위치 UI 추가
- `popup.js`: 토글 기능 및 설정 저장

## 테스트 완료
- [x] API 데이터 파싱 및 개월수 계산
- [x] 검색결과에 라벨 표시 확인
- [x] 팝업 토글 기능 동작
- [x] 분홍색 스타일 및 호버 효과
- [x] 기존 라벨들과의 연동

Closes #7