### PR TITLE
보험사고 라벨 로직 수정: myAccidentCnt/myAccidentCost 사용 (#14)

### DIFF
--- a/content/services/api.js
+++ b/content/services/api.js
@@ -38,10 +38,11 @@
       const labels = [];
       const use = Array.isArray(data.carInfoUse1s) ? data.carInfoUse1s : [];
       if (use.some((c) => ['3', '4'].includes(c))) labels.push({ text: '사용이력있음', type: 'usage' });
-      const my = (data.accidents || []).filter((a) => a.type === '1' || a.type === '2');
-      if (my.length > 0) {
-        const total = my.reduce((s, a) => s + (a.partCost || 0) + (a.laborCost || 0) + (a.paintingCost || 0), 0);
-        labels.push({ text: `내차 보험사고 ${my.length}회 / ${total.toLocaleString()}원`, type: 'insurance' });
+      // 내차 보험사고: API 요약 필드만 사용 (기존 계산식 제거)
+      const myCount = Number(data.myAccidentCnt) || 0;
+      const myTotal = Number(data.myAccidentCost) || 0;
+      if (myCount > 0) {
+        labels.push({ text: `내차 보험사고 ${myCount}회 / ${myTotal.toLocaleString()}원`, type: 'insurance' });
       }
       const oc = data.ownerChanges;
       if (Array.isArray(oc) && oc.length > 0) labels.push({ text: `소유자 변경 ${oc.length}회`, type: 'owner' });


### PR DESCRIPTION
### 개요
API 응답의 `myAccidentCnt`, `myAccidentCost`를 사용해 내차 보험사고 회수/금액을 표시하도록 로직을 교체했습니다. 기존 `accidents` 합산 방식은 제거했습니다.

### 변경사항
- `content/services/api.js`: `fetchVehicleHistory`에서 내차 보험사고 라벨 계산 시 요약 필드만 사용
- 표기: "내차 보험사고 {cnt}회 / {cost}원"

### 관련 이슈
Closes #14