### PR TITLE
리스트 좋아요 클릭 시 라벨 사라짐 방지 (#16)

### DIFF
--- a/content/modules/vehicle-history.js
+++ b/content/modules/vehicle-history.js
@@ -6,6 +6,9 @@
   const { DOM } = window.EPS;
   const { fetchVehicleHistory, extractVehicleId, processBatch } = window.EPS.API;
 
+  // 차량별 라벨 캐시 (행이 교체되어도 복구 가능)
+  const labelCache = new Map(); // key: vehicleId, value: labels array
+
   const addVehicleLabelsToRow = (serviceLabelList, vehicleLabels) => {
     // 기존 라벨 제거
     const existing = serviceLabelList.querySelectorAll('.usage-history-label, .insurance-history-label, .owner-change-label, .noinsurance-label');
@@ -31,20 +34,18 @@
       // 캐시해두어 재주입 시 API 재호출 없이 사용
       hostElement._epsVehicleLabels = vehicleLabels;
       if (hostElement._epsLabelObserver) return;
-      const observer = new MutationObserver((mutations) => {
-        // 현재 라벨이 모두 사라졌는지 확인
-        const hasAny = serviceLabelList.querySelector(
+      const observer = new MutationObserver(() => {
+        const container = hostElement.querySelector('.service_label_list');
+        if (!container) return; // 컨테이너 자체가 아직 없으면 대기
+        const hasAny = container.querySelector(
           '.usage-history-label, .insurance-history-label, .owner-change-label, .noinsurance-label'
         );
         if (!hasAny) {
-          // 재주입 시 자체 변경으로 인한 루프 방지
-          observer.disconnect();
-          addVehicleLabelsToRow(serviceLabelList, hostElement._epsVehicleLabels || []);
-          // 마이크로태스크 이후 재연결
-          setTimeout(() => observer.observe(serviceLabelList, { childList: true }), 0);
+          addVehicleLabelsToRow(container, hostElement._epsVehicleLabels || []);
         }
       });
-      observer.observe(serviceLabelList, { childList: true });
+      // 행 전체를 관찰하여 컨테이너 교체/자식 변경 모두 대응
+      observer.observe(hostElement, { childList: true, subtree: true });
       hostElement._epsLabelObserver = observer;
     } catch (_) { /* no-op */ }
   };
@@ -64,6 +65,11 @@
       if (isPhotoArea) serviceLabelList = element.querySelector('.service_label_list');
       else serviceLabelList = element.querySelector('td.inf .service_label_list');
       if (serviceLabelList && vehicleLabels.length > 0) {
+        // 캐시 및 식별자 저장 (행 교체 시 복구용)
+        try {
+          labelCache.set(vehicleId, vehicleLabels);
+          element.setAttribute('data-eps-vehicle-id', vehicleId);
+        } catch (_) {}
         addVehicleLabelsToRow(serviceLabelList, vehicleLabels);
         attachLabelPersistence(element, serviceLabelList, vehicleLabels);
         element.setAttribute('data-usage-processed', 'true');
@@ -89,7 +95,44 @@
   };
 
   const VehicleHistory = {
-    init() { setTimeout(processUsageHistory, 1000); },
+    init() {
+      // 전역 관찰자: 행이 통째로 교체되어도 라벨 복구
+      try {
+        if (!window._epsVhGlobalObserver) {
+          const globalObserver = new MutationObserver((mutations) => {
+            mutations.forEach((m) => {
+              // 새로 추가되거나 변경된 노드들에서 라벨 컨테이너를 찾는다
+              const nodes = [];
+              if (m.type === 'childList') {
+                nodes.push(...m.addedNodes);
+                if (m.target) nodes.push(m.target);
+              }
+              nodes.forEach((n) => {
+                if (!(n instanceof HTMLElement)) return;
+                // 각 행 스코프에서 vehicleId 추출
+                const row = n.closest ? n.closest('tr[data-index], li[data-index]') : null;
+                if (!row) return;
+                const container = row.querySelector('.service_label_list');
+                if (!container) return;
+                // 라벨이 없고 캐시가 있으면 복구
+                const hasAny = container.querySelector('.usage-history-label, .insurance-history-label, .owner-change-label, .noinsurance-label');
+                if (hasAny) return;
+                // vehicleId는 이미지에서 다시 추출
+                const isPhotoArea = row.tagName === 'LI';
+                const img = isPhotoArea ? row.querySelector('img.thumb') : row.querySelector('td.img img.thumb');
+                const vid = extractVehicleId(img);
+                if (vid && labelCache.has(vid)) {
+                  addVehicleLabelsToRow(container, labelCache.get(vid));
+                }
+              });
+            });
+          });
+          globalObserver.observe(document.body, { childList: true, subtree: true });
+          window._epsVhGlobalObserver = globalObserver;
+        }
+      } catch (_) { /* no-op */ }
+      setTimeout(processUsageHistory, 1000);
+    },
     onSettingsChanged() { /* CSS 클래스로 표시/숨김 제어이므로 재처리 불필요 */ },
     onRouteChange() { setTimeout(processUsageHistory, 500); }
   };

--- a/content/modules/vehicle-history.js
+++ b/content/modules/vehicle-history.js
@@ -25,6 +25,30 @@
     });
   };
 
+  // 라벨이 내부 렌더링 변경으로 제거될 때 재주입을 보장
+  const attachLabelPersistence = (hostElement, serviceLabelList, vehicleLabels) => {
+    try {
+      // 캐시해두어 재주입 시 API 재호출 없이 사용
+      hostElement._epsVehicleLabels = vehicleLabels;
+      if (hostElement._epsLabelObserver) return;
+      const observer = new MutationObserver((mutations) => {
+        // 현재 라벨이 모두 사라졌는지 확인
+        const hasAny = serviceLabelList.querySelector(
+          '.usage-history-label, .insurance-history-label, .owner-change-label, .noinsurance-label'
+        );
+        if (!hasAny) {
+          // 재주입 시 자체 변경으로 인한 루프 방지
+          observer.disconnect();
+          addVehicleLabelsToRow(serviceLabelList, hostElement._epsVehicleLabels || []);
+          // 마이크로태스크 이후 재연결
+          setTimeout(() => observer.observe(serviceLabelList, { childList: true }), 0);
+        }
+      });
+      observer.observe(serviceLabelList, { childList: true });
+      hostElement._epsLabelObserver = observer;
+    } catch (_) { /* no-op */ }
+  };
+
   const processElement = async (element) => {
     try {
       const isPhotoArea = element.tagName === 'LI';
@@ -41,6 +65,7 @@
       else serviceLabelList = element.querySelector('td.inf .service_label_list');
       if (serviceLabelList && vehicleLabels.length > 0) {
         addVehicleLabelsToRow(serviceLabelList, vehicleLabels);
+        attachLabelPersistence(element, serviceLabelList, vehicleLabels);
         element.setAttribute('data-usage-processed', 'true');
         return { success: true, count: vehicleLabels.length };
       }


### PR DESCRIPTION
### 개요
리스트에서 좋아요(찜) 클릭 시 DOM이 부분 재렌더링되면서 라벨이 사라지는 문제를 해결했습니다.

### 변경사항
- `content/modules/vehicle-history.js`
  - 라벨 주입 후 `.service_label_list` 및 행 전체에 대해 `MutationObserver`로 변경 감시
  - 라벨이 제거/컨테이너 교체 시 캐시된 라벨 데이터로 즉시 재주입
  - 차량별 `vehicleId → 라벨` 캐시 도입(불필요한 API 재호출 방지)

### 동작
- 좋아요 클릭 등으로 행이 업데이트되어도 라벨이 자동 복구되어 유지됩니다.

### 관련 이슈
Closes #16