### PR TITLE
팝업에 리뷰 버튼 추가: 리뷰 페이지로 바로 이동 (#20)

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -185,6 +185,28 @@
             background: #f8d7da;
             color: #721c24;
         }
+
+        /* 리뷰 버튼 */
+        .btn {
+            display: inline-block;
+            padding: 8px 12px;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: 600;
+            text-align: center;
+            text-decoration: none;
+            cursor: pointer;
+            border: none;
+        }
+        .btn-primary {
+            background: #ff6b35;
+            color: #fff;
+        }
+        .review-desc {
+            font-size: 12px;
+            color: #666;
+            margin-top: 8px;
+        }
     </style>
 </head>
 <body>
@@ -275,6 +297,12 @@
         </div>
     </div>
     
+    <div class="setting-group">
+        <div class="setting-title">💬 리뷰 참여</div>
+        <button id="openReviewLink" class="btn btn-primary" type="button">Chrome Web Store에 리뷰 남기기</button>
+        <div class="review-desc">사용에 도움이 되셨다면 별점과 리뷰를 남겨주세요!</div>
+    </div>
+
     <div class="version-info">
         <span id="versionInfo">Encar Power Search v...</span>
     </div>

--- a/popup.html
+++ b/popup.html
@@ -202,6 +202,7 @@
             background: #ff6b35;
             color: #fff;
         }
+        .review-actions { text-align: center; }
         .review-desc {
             font-size: 12px;
             color: #666;
@@ -299,7 +300,9 @@
     
     <div class="setting-group">
         <div class="setting-title">💬 리뷰 참여</div>
-        <button id="openReviewLink" class="btn btn-primary" type="button">Chrome Web Store에 리뷰 남기기</button>
+        <div class="review-actions">
+            <button id="openReviewLink" class="btn btn-primary" type="button">Chrome Web Store에 리뷰 남기기</button>
+        </div>
         <div class="review-desc">사용에 도움이 되셨다면 별점과 리뷰를 남겨주세요!</div>
     </div>
 

--- a/popup.html
+++ b/popup.html
@@ -188,8 +188,9 @@
 
         /* 리뷰 버튼 */
         .btn {
-            display: inline-block;
-            padding: 8px 12px;
+            display: block;
+            width: 100%;
+            padding: 10px 12px;
             border-radius: 6px;
             font-size: 13px;
             font-weight: 600;
@@ -197,6 +198,7 @@
             text-decoration: none;
             cursor: pointer;
             border: none;
+            box-sizing: border-box;
         }
         .btn-primary {
             background: #ff6b35;

--- a/popup.js
+++ b/popup.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const showOwnerHistoryToggle = document.getElementById('showOwnerHistory');
     const showNoInsuranceHistoryToggle = document.getElementById('showNoInsuranceHistory');
     const extendPagerowToggle = document.getElementById('extendPagerow');
+  const openReviewLinkBtn = document.getElementById('openReviewLink');
     
     // 초기화
     loadVersionInfo();
@@ -65,6 +66,15 @@ document.addEventListener('DOMContentLoaded', function() {
         savePagerowSettings(this.checked);
         updateActiveTab();
     });
+
+  // 리뷰 링크 열기
+  if (openReviewLinkBtn) {
+    openReviewLinkBtn.addEventListener('click', function() {
+      const url = 'https://chromewebstore.google.com/detail/encar-power-search/fekacphpglpdpebddjfbjdcpljhdaoge/reviews';
+      // 새 탭으로 오픈
+      chrome.tabs.create({ url });
+    });
+  }
     
     // 페이지 상태 확인
     function checkPageStatus() {


### PR DESCRIPTION
### 개요
팝업에 리뷰 참여 버튼을 추가해 사용자가 크롬 웹스토어 리뷰 페이지로 바로 이동할 수 있게 했습니다.

### 변경사항
- `popup.html`: 리뷰 섹션/버튼 추가, 버튼 전체 너비(100%) 적용
- `popup.js`: 버튼 클릭 시 리뷰 페이지를 새 탭으로 오픈
- 리뷰 페이지: https://chromewebstore.google.com/detail/encar-power-search/fekacphpglpdpebddjfbjdcpljhdaoge/reviews

### 관련 이슈
Closes #20