### PR TITLE
설치 기본값: 사진우대/우대등록 섹션 숨김 기본 활성화 (#27)

### DIFF
--- a/content/constants.js
+++ b/content/constants.js
@@ -16,8 +16,8 @@
       photoRow: '#sr_photo li[data-index]'
     },
     defaultSettings: {
-      hidePhotoSection: false,
-      hidePrioritySection: false,
+      hidePhotoSection: true,
+      hidePrioritySection: true,
       showUsageHistory: true,
       showInsuranceHistory: true,
       showOwnerHistory: true,


### PR DESCRIPTION
### 개요
설치 직후 기본 설정을 변경하여 사진우대/우대등록 섹션을 기본으로 숨기도록 했습니다.

### 변경사항
- `content/constants.js`: `defaultSettings`
  - `hidePhotoSection: true`
  - `hidePrioritySection: true`

### 영향
- 신규 설치/초기 상태에서 해당 섹션이 숨김으로 동작 (사용자는 팝업에서 언제든 토글 가능)

### 관련 이슈
Closes #27